### PR TITLE
fix(resources): improve custom_field attribute handling to avoid permanent diffs

### DIFF
--- a/docs/resources/available_prefix.md
+++ b/docs/resources/available_prefix.md
@@ -35,6 +35,7 @@ resource "netbox_available_prefix" "test" {
 
 ### Optional
 
+- `custom_fields` (Map of String)
 - `description` (String)
 - `is_pool` (Boolean)
 - `mark_utilized` (Boolean)

--- a/docs/resources/custom_field_choice_set.md
+++ b/docs/resources/custom_field_choice_set.md
@@ -39,7 +39,6 @@ resource "netbox_custom_field_choice_set" "test" {
 ### Optional
 
 - `base_choices` (String) Valid values are `IATA`, `ISO_3166` and `UN_LOCODE`. At least one of `base_choices` or `extra_choices` must be given.
-- `custom_fields` (Map of String)
 - `description` (String)
 - `extra_choices` (List of List of String) This length of the inner lists must be exactly two, where the first value is the value of a choice and the second value is the label of the choice. At least one of `base_choices` or `extra_choices` must be given.
 - `order_alphabetically` (Boolean) experimental. Defaults to `false`.

--- a/netbox/custom_fields.go
+++ b/netbox/custom_fields.go
@@ -1,6 +1,8 @@
 package netbox
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -9,6 +11,7 @@ const customFieldsKey = "custom_fields"
 var customFieldsSchema = &schema.Schema{
 	Type:     schema.TypeMap,
 	Optional: true,
+	Computed: true,
 	Default:  nil,
 	Elem: &schema.Schema{
 		Type:    schema.TypeString,
@@ -16,10 +19,57 @@ var customFieldsSchema = &schema.Schema{
 	},
 }
 
-func getCustomFields(cf interface{}) map[string]interface{} {
-	cfm, ok := cf.(map[string]interface{})
-	if !ok || len(cfm) == 0 {
+var customFieldsSchemaRead = &schema.Schema{
+	Type:     schema.TypeMap,
+	Computed: true,
+	Elem: &schema.Schema{
+		Type:    schema.TypeString,
+	},
+}
+
+func customFieldsDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	cfg := d.GetRawConfig().GetAttr(customFieldsKey)
+	cfm, ok := d.Get(customFieldsKey).(map[string]interface{})
+
+	if cfg.IsNull() || !ok {
+		d.SetNew(customFieldsKey, nil)
 		return nil
 	}
-	return cfm
+
+	for k, v := range cfm {
+		if v == "" {
+			delete(cfm, k)
+		}
+	}
+
+	d.SetNew(customFieldsKey, cfm)
+	return nil
+}
+
+func computeCustomFieldsModel(d *schema.ResourceData) interface{} {
+	oldcf, newcf := d.GetChange(customFieldsKey)
+
+	oldcfm, _ := oldcf.(map[string]interface{})
+	newcfm, _ := newcf.(map[string]interface{})
+
+	for k := range oldcfm {
+		if _, ok := newcfm[k]; !ok {
+			newcfm[k] = ""
+		}
+	}
+
+	return newcfm
+}
+
+func computeCustomFieldsAttr(cf interface{}) map[string]interface{} {
+	cfm, _ := cf.(map[string]interface{})
+	newcfm := make(map[string]interface{})
+
+	for k, v := range cfm {
+		if vs, _ := v.(string); vs != "" {
+			newcfm[k] = v
+		}
+	}
+
+	return newcfm
 }

--- a/netbox/custom_fields.go
+++ b/netbox/custom_fields.go
@@ -23,7 +23,7 @@ var customFieldsSchemaRead = &schema.Schema{
 	Type:     schema.TypeMap,
 	Computed: true,
 	Elem: &schema.Schema{
-		Type:    schema.TypeString,
+		Type: schema.TypeString,
 	},
 }
 

--- a/netbox/custom_fields.go
+++ b/netbox/custom_fields.go
@@ -27,30 +27,28 @@ var customFieldsSchemaRead = &schema.Schema{
 	},
 }
 
-func customFieldsDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	cfg := d.GetRawConfig().GetAttr(customFieldsKey)
-	cfm, ok := d.Get(customFieldsKey).(map[string]interface{})
-
-	if cfg.IsNull() || !ok {
-		d.SetNew(customFieldsKey, nil)
-		return nil
-	}
+func normalizeCustomFields(cfm map[string]interface{}) map[string]interface{} {
+	newcfm := make(map[string]interface{})
 
 	for k, v := range cfm {
-		if v == "" {
-			delete(cfm, k)
+		if v != nil && v != "" {
+			newcfm[k] = v
 		}
 	}
 
-	d.SetNew(customFieldsKey, cfm)
-	return nil
+	return newcfm
 }
 
-func computeCustomFieldsModel(d *schema.ResourceData) interface{} {
-	oldcf, newcf := d.GetChange(customFieldsKey)
+func mergeCustomFields(oldcfm, newcfm map[string]interface{}) map[string]interface{} {
+	if newcfm == nil {
+		newcfm = make(map[string]interface{})
+	}
 
-	oldcfm, _ := oldcf.(map[string]interface{})
-	newcfm, _ := newcf.(map[string]interface{})
+	for k, v := range newcfm {
+		if v == nil {
+			newcfm[k] = ""
+		}
+	}
 
 	for k := range oldcfm {
 		if _, ok := newcfm[k]; !ok {
@@ -61,15 +59,29 @@ func computeCustomFieldsModel(d *schema.ResourceData) interface{} {
 	return newcfm
 }
 
-func computeCustomFieldsAttr(cf interface{}) map[string]interface{} {
-	cfm, _ := cf.(map[string]interface{})
-	newcfm := make(map[string]interface{})
+func customFieldsDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	cfg := d.GetRawConfig().GetAttr(customFieldsKey)
+	cfm, ok := d.Get(customFieldsKey).(map[string]interface{})
 
-	for k, v := range cfm {
-		if vs, _ := v.(string); vs != "" {
-			newcfm[k] = v
-		}
+	if cfg.IsNull() || !ok {
+		d.SetNew(customFieldsKey, nil)
+	} else {
+		newcfm := normalizeCustomFields(cfm)
+		d.SetNew(customFieldsKey, newcfm)
 	}
 
-	return newcfm
+	return nil
+}
+
+func computeCustomFieldsAttr(cf interface{}) map[string]interface{} {
+	cfm, _ := cf.(map[string]interface{})
+	return normalizeCustomFields(cfm)
+}
+
+func computeCustomFieldsModel(d *schema.ResourceData) interface{} {
+	oldcf, newcf := d.GetChange(customFieldsKey)
+
+	oldcfm, _ := oldcf.(map[string]interface{})
+	newcfm, _ := newcf.(map[string]interface{})
+	return mergeCustomFields(oldcfm, newcfm)
 }

--- a/netbox/custom_fields_test.go
+++ b/netbox/custom_fields_test.go
@@ -1,0 +1,185 @@
+package netbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomFields_normalize(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "MapNil",
+			input:    nil,
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "MapEmpty",
+			input:    map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "MapFull",
+			input: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expected: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "MapMixed",
+			input: map[string]interface{}{
+				"key1": "value1",
+				"key2": "",
+				"key3": nil,
+			},
+			expected: map[string]interface{}{
+				"key1": "value1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeCustomFields(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCustomFields_merge(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    map[string]interface{}
+		input    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "MapNilBoth",
+			state:    nil,
+			input:    nil,
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "MapNilNew",
+			state:    map[string]interface{}{},
+			input:    nil,
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "MapNilOld",
+			state:    nil,
+			input:    map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "MapUnsetWithMissing",
+			state: map[string]interface{}{
+				"key1": "value1",
+			},
+			input: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"key1": "",
+			},
+		},
+		{
+			name: "MapUnsetWithNil",
+			state: map[string]interface{}{
+				"key1": "value1",
+			},
+			input: map[string]interface{}{
+				"key1": nil,
+			},
+			expected: map[string]interface{}{
+				"key1": "",
+			},
+		},
+		{
+			name: "MapUnsetWithEmpty",
+			state: map[string]interface{}{
+				"key1": "value1",
+			},
+			input: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"key1": "",
+			},
+		},
+		{
+			name:  "MapUnsetWithNilNotSet",
+			state: map[string]interface{}{},
+			input: map[string]interface{}{
+				"key1": nil,
+			},
+			expected: map[string]interface{}{
+				"key1": "",
+			},
+		},
+		{
+			name:  "MapUnsetWithEmptyNotSet",
+			state: map[string]interface{}{},
+			input: map[string]interface{}{
+				"key1": "",
+			},
+			expected: map[string]interface{}{
+				"key1": "",
+			},
+		},
+		{
+			name:  "MapSetNew",
+			state: map[string]interface{}{},
+			input: map[string]interface{}{
+				"key1": "test",
+			},
+			expected: map[string]interface{}{
+				"key1": "test",
+			},
+		},
+		{
+			name: "MapSetExisting",
+			state: map[string]interface{}{
+				"key1": " test",
+			},
+			input: map[string]interface{}{
+				"key1": "testnew",
+			},
+			expected: map[string]interface{}{
+				"key1": "testnew",
+			},
+		},
+		{
+			name: "MapMixed",
+			state: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "",
+				"key4": nil,
+			},
+			input: map[string]interface{}{
+				"key1":   "valuenew1",
+				"key2":   nil,
+				"keynew": "valuenew2",
+			},
+			expected: map[string]interface{}{
+				"key1":   "valuenew1",
+				"key2":   "",
+				"key3":   "",
+				"key4":   "",
+				"keynew": "valuenew2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeCustomFields(tt.state, tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/netbox/data_source_netbox_cluster.go
+++ b/netbox/data_source_netbox_cluster.go
@@ -54,7 +54,7 @@ func dataSourceNetboxCluster() *schema.Resource {
 				Optional: true,
 			},
 			customFieldsKey: customFieldsSchemaRead,
-			tagsKey: tagsSchemaRead,
+			tagsKey:         tagsSchemaRead,
 		},
 	}
 }

--- a/netbox/data_source_netbox_cluster.go
+++ b/netbox/data_source_netbox_cluster.go
@@ -53,10 +53,7 @@ func dataSourceNetboxCluster() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
-			"custom_fields": {
-				Type:     schema.TypeMap,
-				Computed: true,
-			},
+			customFieldsKey: customFieldsSchemaRead,
 			tagsKey: tagsSchemaRead,
 		},
 	}
@@ -116,10 +113,10 @@ func dataSourceNetboxClusterRead(d *schema.ResourceData, m interface{}) error {
 	} else {
 		d.Set("site_id", nil)
 	}
-	if result.CustomFields != nil {
-		d.Set("custom_fields", result.CustomFields)
-	}
+
+	d.Set(customFieldsKey, result.CustomFields)
 
 	d.Set(tagsKey, getTagListFromNestedTagList(result.Tags))
+
 	return nil
 }

--- a/netbox/data_source_netbox_prefix.go
+++ b/netbox/data_source_netbox_prefix.go
@@ -27,7 +27,6 @@ func dataSourceNetboxPrefix() *schema.Resource {
 				ValidateFunc:  validation.IsCIDR,
 				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 			},
-			customFieldsKey: customFieldsSchema,
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -94,7 +93,8 @@ for more information on available lookup expressions.`,
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": tagsSchemaRead,
+			customFieldsKey: customFieldsSchemaRead,
+			tagsKey: tagsSchemaRead,
 		},
 	}
 }
@@ -174,12 +174,11 @@ func dataSourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("status", result.Status.Value)
 	d.Set("description", result.Description)
 	d.Set("family", int(*result.Family.Value))
-	d.Set("tags", getTagListFromNestedTagList(result.Tags))
 
-	cf := getCustomFields(result.CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, result.CustomFields)
+
+	d.Set(tagsKey, getTagListFromNestedTagList(result.Tags))
+
 	if result.Role != nil {
 		d.Set("role_id", result.Role.ID)
 	}

--- a/netbox/data_source_netbox_prefix.go
+++ b/netbox/data_source_netbox_prefix.go
@@ -94,7 +94,7 @@ for more information on available lookup expressions.`,
 				Computed: true,
 			},
 			customFieldsKey: customFieldsSchemaRead,
-			tagsKey: tagsSchemaRead,
+			tagsKey:         tagsSchemaRead,
 		},
 	}
 }

--- a/netbox/data_source_netbox_racks.go
+++ b/netbox/data_source_netbox_racks.go
@@ -136,7 +136,7 @@ func dataSourceNetboxRacks() *schema.Resource {
 							Computed: true,
 						},
 						customFieldsKey: customFieldsSchemaRead,
-						tagsKey: tagsSchemaRead,
+						tagsKey:         tagsSchemaRead,
 					},
 				},
 			},

--- a/netbox/data_source_netbox_racks.go
+++ b/netbox/data_source_netbox_racks.go
@@ -67,7 +67,6 @@ func dataSourceNetboxRacks() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
-						tagsKey: tagsSchemaRead,
 						"tenant_id": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -136,10 +135,8 @@ func dataSourceNetboxRacks() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"custom_fields": {
-							Type:     schema.TypeMap,
-							Computed: true,
-						},
+						customFieldsKey: customFieldsSchemaRead,
+						tagsKey: tagsSchemaRead,
 					},
 				},
 			},
@@ -246,7 +243,6 @@ func dataSourceNetboxRacksRead(d *schema.ResourceData, m interface{}) error {
 			mapping["width"] = v.Width.Value
 		}
 		mapping["u_height"] = v.UHeight
-		mapping["tags"] = getTagListFromNestedTagList(v.Tags)
 		if v.Tenant != nil {
 			mapping["tenant_id"] = v.Tenant.ID
 		}
@@ -273,7 +269,10 @@ func dataSourceNetboxRacksRead(d *schema.ResourceData, m interface{}) error {
 		mapping["mounting_depth"] = v.MountingDepth
 		mapping["description"] = v.Description
 		mapping["comments"] = v.Comments
-		mapping["custom_fields"] = getCustomFields(v.CustomFields)
+
+		mapping[customFieldsKey] = v.CustomFields
+
+		mapping[tagsKey] = getTagListFromNestedTagList(v.Tags)
 
 		s = append(s, mapping)
 	}

--- a/netbox/data_source_netbox_tenants.go
+++ b/netbox/data_source_netbox_tenants.go
@@ -72,11 +72,6 @@ func dataSourceNetboxTenants() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"custom_fields": {
-							Type:     schema.TypeMap,
-							Computed: true,
-						},
-
 						"site_count": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -141,6 +136,7 @@ func dataSourceNetboxTenants() *schema.Resource {
 								},
 							},
 						},
+						customFieldsKey: customFieldsSchemaRead,
 					},
 				},
 			},
@@ -196,7 +192,6 @@ func dataSourceNetboxTenantsRead(d *schema.ResourceData, m interface{}) error {
 		mapping["created"] = v.Created.String()
 		mapping["last_updated"] = v.LastUpdated.String()
 		mapping["comments"] = v.Comments
-		mapping["custom_fields"] = v.CustomFields
 
 		mapping["site_count"] = v.SiteCount
 		mapping["rack_count"] = v.RackCount
@@ -210,6 +205,9 @@ func dataSourceNetboxTenantsRead(d *schema.ResourceData, m interface{}) error {
 		mapping["cluster_count"] = v.ClusterCount
 
 		mapping["tenant_group"] = flattenTenantGroup(v.Group)
+
+		mapping[customFieldsKey] = v.CustomFields
+
 		s = append(s, mapping)
 	}
 

--- a/netbox/resource_netbox_available_prefix.go
+++ b/netbox/resource_netbox_available_prefix.go
@@ -77,7 +77,7 @@ func resourceNetboxAvailablePrefix() *schema.Resource {
 				Optional: true,
 			},
 			customFieldsKey: customFieldsSchema,
-			tagsKey: tagsSchema,
+			tagsKey:         tagsSchema,
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: func(c context.Context, rd *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/netbox/resource_netbox_available_prefix.go
+++ b/netbox/resource_netbox_available_prefix.go
@@ -76,6 +76,7 @@ func resourceNetboxAvailablePrefix() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			customFieldsKey: customFieldsSchema,
 			tagsKey: tagsSchema,
 		},
 		Importer: &schema.ResourceImporter{

--- a/netbox/resource_netbox_circuit_termination.go
+++ b/netbox/resource_netbox_circuit_termination.go
@@ -48,9 +48,10 @@ func resourceNetboxCircuitTermination() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(resourceNetboxCircuitTerminationTermSideOptions, false),
 				Description:  buildValidValueDescription(resourceNetboxCircuitTerminationTermSideOptions),
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -85,12 +86,9 @@ func resourceNetboxCircuitTerminationCreate(d *schema.ResourceData, m interface{
 		data.UpstreamSpeed = int64ToPtr(int64(upstreamspeedValue.(int)))
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := circuits.NewCircuitsCircuitTerminationsCreateParams().WithData(&data)
 
@@ -151,12 +149,9 @@ func resourceNetboxCircuitTerminationRead(d *schema.ResourceData, m interface{})
 		d.Set("upstream_speed", nil)
 	}
 
-	d.Set(tagsKey, getTagListFromNestedTagList(term.Tags))
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
 
-	cf := getCustomFields(term.CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(tagsKey, getTagListFromNestedTagList(term.Tags))
 
 	return nil
 }
@@ -190,12 +185,9 @@ func resourceNetboxCircuitTerminationUpdate(d *schema.ResourceData, m interface{
 		data.UpstreamSpeed = int64ToPtr(int64(upstreamspeedValue.(int)))
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	cf, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = cf
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := circuits.NewCircuitsCircuitTerminationsPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_custom_field_choice_set.go
+++ b/netbox/resource_netbox_custom_field_choice_set.go
@@ -76,7 +76,6 @@ A choice set must define a base choice set and/or a set of arbitrary extra choic
 				Description: "experimental",
 				Default:     false,
 			},
-			customFieldsKey: customFieldsSchema,
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/netbox/resource_netbox_device.go
+++ b/netbox/resource_netbox_device.go
@@ -134,7 +134,7 @@ func resourceNetboxDevice() *schema.Resource {
 				Description: "This is best managed through the use of `jsonencode` and a map of settings.",
 			},
 			customFieldsKey: customFieldsSchema,
-			tagsKey: tagsSchema,
+			tagsKey:         tagsSchema,
 		},
 		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{

--- a/netbox/resource_netbox_device_console_port.go
+++ b/netbox/resource_netbox_device_console_port.go
@@ -56,9 +56,10 @@ func resourceNetboxDeviceConsolePort() *schema.Resource {
 				Default:  false,
 				Optional: true,
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -79,12 +80,9 @@ func resourceNetboxDeviceConsolePortCreate(d *schema.ResourceData, m interface{}
 		MarkConnected: d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimConsolePortsCreateParams().WithData(&data)
 
@@ -147,10 +145,8 @@ func resourceNetboxDeviceConsolePortRead(d *schema.ResourceData, m interface{}) 
 	d.Set("description", consolePort.Description)
 	d.Set("mark_connected", consolePort.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 
 	return nil
@@ -172,12 +168,9 @@ func resourceNetboxDeviceConsolePortUpdate(d *schema.ResourceData, m interface{}
 		MarkConnected: d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimConsolePortsPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_device_console_server_port.go
+++ b/netbox/resource_netbox_device_console_server_port.go
@@ -56,9 +56,10 @@ func resourceNetboxDeviceConsoleServerPort() *schema.Resource {
 				Default:  false,
 				Optional: true,
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -79,12 +80,9 @@ func resourceNetboxDeviceConsoleServerPortCreate(d *schema.ResourceData, m inter
 		MarkConnected: d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimConsoleServerPortsCreateParams().WithData(&data)
 
@@ -147,10 +145,8 @@ func resourceNetboxDeviceConsoleServerPortRead(d *schema.ResourceData, m interfa
 	d.Set("description", consoleServerPort.Description)
 	d.Set("mark_connected", consoleServerPort.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 
 	return nil
@@ -172,12 +168,9 @@ func resourceNetboxDeviceConsoleServerPortUpdate(d *schema.ResourceData, m inter
 		MarkConnected: d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimConsoleServerPortsPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_device_front_port.go
+++ b/netbox/resource_netbox_device_front_port.go
@@ -63,9 +63,10 @@ func resourceNetboxDeviceFrontPort() *schema.Resource {
 				Default:  false,
 				Optional: true,
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -88,12 +89,9 @@ func resourceNetboxDeviceFrontPortCreate(d *schema.ResourceData, m interface{}) 
 		MarkConnected:    d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimFrontPortsCreateParams().WithData(&data)
 
@@ -159,10 +157,8 @@ func resourceNetboxDeviceFrontPortRead(d *schema.ResourceData, m interface{}) er
 	d.Set("description", frontPort.Description)
 	d.Set("mark_connected", frontPort.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 
 	return nil
@@ -186,12 +182,9 @@ func resourceNetboxDeviceFrontPortUpdate(d *schema.ResourceData, m interface{}) 
 		MarkConnected:    d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimFrontPortsPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_device_module_bay.go
+++ b/netbox/resource_netbox_device_module_bay.go
@@ -43,9 +43,10 @@ func resourceNetboxDeviceModuleBay() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -63,12 +64,9 @@ func resourceNetboxDeviceModuleBayCreate(d *schema.ResourceData, m interface{}) 
 		Description: getOptionalStr(d, "description", false),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimModuleBaysCreateParams().WithData(&data)
 
@@ -112,10 +110,8 @@ func resourceNetboxDeviceModuleBayRead(d *schema.ResourceData, m interface{}) er
 	d.Set("position", moduleBay.Position)
 	d.Set("description", moduleBay.Description)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 
 	return nil
@@ -134,12 +130,9 @@ func resourceNetboxDeviceModuleBayUpdate(d *schema.ResourceData, m interface{}) 
 		Description: getOptionalStr(d, "description", true),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimModuleBaysPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_device_power_outlet.go
+++ b/netbox/resource_netbox_device_power_outlet.go
@@ -64,9 +64,10 @@ For example, imagine a PDU with one power port which draws from a three-phase fe
 				Default:  false,
 				Optional: true,
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -88,12 +89,9 @@ func resourceNetboxDevicePowerOutletCreate(d *schema.ResourceData, m interface{}
 		MarkConnected: d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimPowerOutletsCreateParams().WithData(&data)
 
@@ -163,10 +161,8 @@ func resourceNetboxDevicePowerOutletRead(d *schema.ResourceData, m interface{}) 
 	d.Set("description", powerOutlet.Description)
 	d.Set("mark_connected", powerOutlet.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 
 	return nil
@@ -189,12 +185,9 @@ func resourceNetboxDevicePowerOutletUpdate(d *schema.ResourceData, m interface{}
 		MarkConnected: d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimPowerOutletsPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_device_power_port.go
+++ b/netbox/resource_netbox_device_power_port.go
@@ -59,9 +59,10 @@ func resourceNetboxDevicePowerPort() *schema.Resource {
 				Default:  false,
 				Optional: true,
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -83,12 +84,9 @@ func resourceNetboxDevicePowerPortCreate(d *schema.ResourceData, m interface{}) 
 		MarkConnected: d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimPowerPortsCreateParams().WithData(&data)
 
@@ -149,10 +147,8 @@ func resourceNetboxDevicePowerPortRead(d *schema.ResourceData, m interface{}) er
 	d.Set("description", powerPort.Description)
 	d.Set("mark_connected", powerPort.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 
 	return nil
@@ -175,12 +171,9 @@ func resourceNetboxDevicePowerPortUpdate(d *schema.ResourceData, m interface{}) 
 		MarkConnected: d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimPowerPortsPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_device_rear_port.go
+++ b/netbox/resource_netbox_device_rear_port.go
@@ -59,9 +59,10 @@ func resourceNetboxDeviceRearPort() *schema.Resource {
 				Default:  false,
 				Optional: true,
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -83,12 +84,9 @@ func resourceNetboxDeviceRearPortCreate(d *schema.ResourceData, m interface{}) e
 		MarkConnected: d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimRearPortsCreateParams().WithData(&data)
 
@@ -148,10 +146,8 @@ func resourceNetboxDeviceRearPortRead(d *schema.ResourceData, m interface{}) err
 	d.Set("description", rearPort.Description)
 	d.Set("mark_connected", rearPort.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 
 	return nil
@@ -174,12 +170,9 @@ func resourceNetboxDeviceRearPortUpdate(d *schema.ResourceData, m interface{}) e
 		MarkConnected: d.Get("mark_connected").(bool),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimRearPortsPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_inventory_item_role.go
+++ b/netbox/resource_netbox_inventory_item_role.go
@@ -39,9 +39,10 @@ func resourceNetboxInventoryItemRole() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -57,12 +58,9 @@ func resourceNetboxInventoryItemRoleCreate(d *schema.ResourceData, m interface{}
 		Color:       getOptionalStr(d, "color_hex", false),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimInventoryItemRolesCreateParams().WithData(&data)
 
@@ -99,10 +97,8 @@ func resourceNetboxInventoryItemRoleRead(d *schema.ResourceData, m interface{}) 
 	d.Set("color_hex", role.Color)
 	d.Set("description", role.Description)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 
 	return nil
@@ -120,12 +116,9 @@ func resourceNetboxInventoryItemRoleUpdate(d *schema.ResourceData, m interface{}
 		Color:       getOptionalStr(d, "color_hex", false),
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimInventoryItemRolesPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_ip_address.go
+++ b/netbox/resource_netbox_ip_address.go
@@ -108,7 +108,7 @@ func resourceNetboxIPAddress() *schema.Resource {
 				},
 			},
 			customFieldsKey: customFieldsSchema,
-			tagsKey: tagsSchema,
+			tagsKey:         tagsSchema,
 		},
 		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{

--- a/netbox/resource_netbox_location.go
+++ b/netbox/resource_netbox_location.go
@@ -46,13 +46,14 @@ Each location must have a name that is unique within its parent site and locatio
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			tagsKey: tagsSchema,
 			"tenant_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
 			customFieldsKey: customFieldsSchema,
+			tagsKey: tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -92,12 +93,9 @@ func resourceNetboxLocationCreate(d *schema.ResourceData, m interface{}) error {
 		data.Tenant = int64ToPtr(int64(tenantIDValue.(int)))
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimLocationsCreateParams().WithData(&data)
 
@@ -154,10 +152,8 @@ func resourceNetboxLocationRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("tenant_id", nil)
 	}
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 
 	return nil
@@ -200,12 +196,9 @@ func resourceNetboxLocationUpdate(d *schema.ResourceData, m interface{}) error {
 		data.Tenant = int64ToPtr(int64(tenantIDValue.(int)))
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	cf, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = cf
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimLocationsPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_location.go
+++ b/netbox/resource_netbox_location.go
@@ -51,7 +51,7 @@ Each location must have a name that is unique within its parent site and locatio
 				Optional: true,
 			},
 			customFieldsKey: customFieldsSchema,
-			tagsKey: tagsSchema,
+			tagsKey:         tagsSchema,
 		},
 		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{

--- a/netbox/resource_netbox_rack.go
+++ b/netbox/resource_netbox_rack.go
@@ -143,7 +143,7 @@ Each rack is assigned a name and (optionally) a separate facility ID. This is he
 				Optional: true,
 			},
 			customFieldsKey: customFieldsSchema,
-			tagsKey: tagsSchema,
+			tagsKey:         tagsSchema,
 		},
 		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{

--- a/netbox/resource_netbox_service.go
+++ b/netbox/resource_netbox_service.go
@@ -66,7 +66,7 @@ func resourceNetboxService() *schema.Resource {
 				ExactlyOneOf: []string{"virtual_machine_id", "device_id"},
 			},
 			customFieldsKey: customFieldsSchema,
-			tagsKey: tagsSchema,
+			tagsKey:         tagsSchema,
 		},
 		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{

--- a/netbox/resource_netbox_site.go
+++ b/netbox/resource_netbox_site.go
@@ -95,7 +95,7 @@ func resourceNetboxSite() *schema.Resource {
 				},
 			},
 			customFieldsKey: customFieldsSchema,
-			tagsKey: tagsSchema,
+			tagsKey:         tagsSchema,
 		},
 		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{

--- a/netbox/resource_netbox_site.go
+++ b/netbox/resource_netbox_site.go
@@ -83,7 +83,6 @@ func resourceNetboxSite() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			tagsKey: tagsSchema,
 			"timezone": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -96,7 +95,9 @@ func resourceNetboxSite() *schema.Resource {
 				},
 			},
 			customFieldsKey: customFieldsSchema,
+			tagsKey: tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -173,12 +174,9 @@ func resourceNetboxSiteCreate(d *schema.ResourceData, m interface{}) error {
 		data.Asns = toInt64List(asnsValue)
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimSitesCreateParams().WithData(&data)
 
@@ -243,10 +241,8 @@ func resourceNetboxSiteRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("tenant_id", nil)
 	}
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 
 	return nil
@@ -332,12 +328,9 @@ func resourceNetboxSiteUpdate(d *schema.ResourceData, m interface{}) error {
 		data.Asns = toInt64List(asnsValue)
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.CustomFields = computeCustomFieldsModel(d)
 
-	cf, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = cf
-	}
+	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := dcim.NewDcimSitesPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_virtual_chassis.go
+++ b/netbox/resource_netbox_virtual_chassis.go
@@ -38,9 +38,10 @@ func resourceNetboxVirtualChassis() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -74,10 +75,7 @@ func resourceNetboxVirtualChassisCreate(ctx context.Context, d *schema.ResourceD
 		data.Comments = comments
 	}
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.CustomFields = computeCustomFieldsModel(d)
 
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
@@ -119,10 +117,7 @@ func resourceNetboxVirtualChassisRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("description", virtualChassis.Description)
 	d.Set("comments", virtualChassis.Comments)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
 
 	d.Set(tagsKey, getTagListFromNestedTagList(virtualChassis.Tags))
 	return nil
@@ -143,10 +138,7 @@ func resourceNetboxVirtualChassisUpdate(ctx context.Context, d *schema.ResourceD
 		data.Domain = domain
 	}
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.CustomFields = computeCustomFieldsModel(d)
 
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 

--- a/netbox/resource_netbox_virtual_disk.go
+++ b/netbox/resource_netbox_virtual_disk.go
@@ -38,9 +38,10 @@ func resourceNetboxVirtualDisks() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
-			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
+		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -66,10 +67,7 @@ func resourceNetboxVirtualDisksCreate(ctx context.Context, d *schema.ResourceDat
 		data.Description = description
 	}
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.CustomFields = computeCustomFieldsModel(d)
 
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
@@ -116,10 +114,7 @@ func resourceNetboxVirtualDisksRead(ctx context.Context, d *schema.ResourceData,
 		d.Set("virtual_machine_id", VirtualDisks.VirtualMachine.ID)
 	}
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
-	if cf != nil {
-		d.Set(customFieldsKey, cf)
-	}
+	d.Set(customFieldsKey, res.GetPayload().CustomFields)
 
 	d.Set(tagsKey, getTagListFromNestedTagList(VirtualDisks.Tags))
 	return nil
@@ -139,10 +134,7 @@ func resourceNetboxVirtualDisksUpdate(ctx context.Context, d *schema.ResourceDat
 	data.Size = &size
 	data.VirtualMachine = &virtualMachineID
 
-	ct, ok := d.GetOk(customFieldsKey)
-	if ok {
-		data.CustomFields = ct
-	}
+	data.CustomFields = computeCustomFieldsModel(d)
 
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 

--- a/netbox/resource_netbox_virtual_machine.go
+++ b/netbox/resource_netbox_virtual_machine.go
@@ -99,7 +99,7 @@ func resourceNetboxVirtualMachine() *schema.Resource {
 				Description: "This is best managed through the use of `jsonencode` and a map of settings.",
 			},
 			customFieldsKey: customFieldsSchema,
-			tagsKey: tagsSchema,
+			tagsKey:         tagsSchema,
 		},
 		CustomizeDiff: customFieldsDiff,
 		Importer: &schema.ResourceImporter{


### PR DESCRIPTION
This pull request improves the handling of the `custom_fields` attribute present in many resources. The NetBox API always returns **all** custom fields for a particular object, whether they are set or not, with unset fields being represented as nulls or empty strings.

Currently, this behavior causes permanent differences in execution plans if users do not specify all custom fields, even when only some of them have values. This is common when adding a new custom field to an object that is already managed in Terraform. All the resources created will then have a difference unless the user includes the new custom field in the resource definition, even if they don't want to set a value for it.

To address this, the `custom_fields` attribute has been marked as `Computed`, allowing it to be modified internally. A `CustomizeDiff` function has been added to the schema of all resources using custom fields to manage the internal state of this attribute effectively and identify real differences and fake ones.

Also, this issue has been noticed before in some open pull requests, including #242 and #632. This change should resolve the permanent diff behaviour in the tests of those PRs.