### PR TITLE
feat: add tenant_id filter to netbox_prefix and netbox_prefixes datasources

### DIFF
--- a/docs/data-sources/prefix.md
+++ b/docs/data-sources/prefix.md
@@ -17,20 +17,21 @@ description: |-
 
 ### Optional
 
-- `cidr` (String, Deprecated) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `role_id`, `cidr` or `tag` must be given. Conflicts with `prefix`.
+- `cidr` (String, Deprecated) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given. Conflicts with `prefix`.
 - `custom_fields` (Map of String)
-- `description` (String) Description to include in the data source filter. At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
-- `family` (Number) The IP family of the prefix. One of 4 or 6. At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
-- `prefix` (String) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `role_id`, `cidr` or `tag` must be given. Conflicts with `cidr`.
-- `role_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
-- `site_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
-- `tag` (String) Tag to include in the data source filter (must match the tag's slug). At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
+- `description` (String) Description to include in the data source filter. At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
+- `family` (Number) The IP family of the prefix. One of 4 or 6. At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
+- `prefix` (String) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given. Conflicts with `cidr`.
+- `role_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
+- `tenant_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
+- `site_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
+- `tag` (String) Tag to include in the data source filter (must match the tag's slug). At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
 - `tag__n` (String) Tag to exclude from the data source filter (must match the tag's slug).
 Refer to [Netbox's documentation](https://demo.netbox.dev/static/docs/rest-api/filtering/#lookup-expressions)
 for more information on available lookup expressions.
-- `vlan_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
-- `vlan_vid` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
-- `vrf_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
+- `vlan_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
+- `vlan_vid` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
+- `vrf_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `tenant_id`, `site_id`, `role_id`, `cidr` or `tag` must be given.
 
 ### Read-Only
 

--- a/docs/data-sources/prefixes.md
+++ b/docs/data-sources/prefixes.md
@@ -30,7 +30,7 @@ description: |-
 
 Required:
 
-- `name` (String) The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `site_id`, & `tag`.
+- `name` (String) The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, & `tag`.
 - `value` (String) The value to pass to the specified filter.
 
 
@@ -42,6 +42,7 @@ Read-Only:
 - `description` (String)
 - `id` (Number)
 - `prefix` (String)
+- `tenant_id` (Number)
 - `site_id` (Number)
 - `status` (String)
 - `tags` (Set of String)

--- a/netbox/data_source_netbox_prefix.go
+++ b/netbox/data_source_netbox_prefix.go
@@ -25,21 +25,21 @@ func dataSourceNetboxPrefix() *schema.Resource {
 				Deprecated:    "The `cidr` parameter is deprecated in favor of the canonical `prefix` attribute.",
 				ConflictsWith: []string{"prefix"},
 				ValidateFunc:  validation.IsCIDR,
-				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
+				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			customFieldsKey: customFieldsSchema,
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
 				Description:  "Description to include in the data source filter.",
 			},
 			"family": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
 				ValidateFunc: validation.IntInSlice([]int{4, 6}),
 				Description:  "The IP family of the prefix. One of 4 or 6",
 			},
@@ -47,40 +47,45 @@ func dataSourceNetboxPrefix() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ValidateFunc:  validation.IsCIDR,
 				ConflictsWith: []string{"cidr"},
-				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
+				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"vlan_vid": {
 				Type:         schema.TypeFloat,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
 				ValidateFunc: validation.FloatBetween(1, 4094),
 			},
 			"vrf_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"vlan_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
+			},
+			"tenant_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"site_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"tag": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "tenant_id", "site_id", "role_id", "cidr", "tag"},
 				Description:  "Tag to include in the data source filter (must match the tag's slug).",
 			},
 			"tag__n": {
@@ -143,6 +148,11 @@ func dataSourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 		params.VlanVid = &vlanVid
 	}
 
+	if tenantID, ok := d.Get("tenant_id").(int); ok && tenantID != 0 {
+		// Note that tenant_id is a string pointer in the netbox filter, but we use a number in the provider
+		params.TenantID = strToPtr(strconv.Itoa(tenantID))
+	}
+
 	if siteID, ok := d.Get("site_id").(int); ok && siteID != 0 {
 		// Note that site_id is a string pointer in the netbox filter, but we use a number in the provider
 		params.SiteID = strToPtr(strconv.Itoa(siteID))
@@ -189,6 +199,9 @@ func dataSourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 	if result.Vlan != nil {
 		d.Set("vlan_vid", result.Vlan.Vid)
 		d.Set("vlan_id", result.Vlan.ID)
+	}
+	if result.Tenant != nil {
+		d.Set("tenant_id", result.Tenant.ID)
 	}
 	if result.Site != nil {
 		d.Set("site_id", result.Site.ID)

--- a/netbox/data_source_netbox_prefix_test.go
+++ b/netbox/data_source_netbox_prefix_test.go
@@ -28,30 +28,36 @@ resource "netbox_vlan" "test" {
   vid  = %[4]d
 }
 
+resource "netbox_tenant" "test" {
+  name = "%[1]s_tenant"
+}
+
 resource "netbox_site" "test" {
   name = "%[1]s_site"
 }
 
 resource "netbox_ipam_role" "test" {
-  name        = "%[1]s_role"
+  name = "%[1]s_role"
 }
 
 resource "netbox_prefix" "testv4" {
-  prefix = "%[2]s"
-  status = "active"
-  vrf_id = netbox_vrf.test.id
-  vlan_id = netbox_vlan.test.id
-  site_id = netbox_site.test.id
-  role_id = netbox_ipam_role.test.id
+  prefix      = "%[2]s"
+  status      = "active"
+  vrf_id      = netbox_vrf.test.id
+  vlan_id     = netbox_vlan.test.id
+  tenant_id   = netbox_tenant.test.id
+  site_id     = netbox_site.test.id
+  role_id     = netbox_ipam_role.test.id
   description = "%[1]s_description_test_idv4"
 }
 
 resource "netbox_prefix" "testv6" {
-  prefix = "%[3]s"
-  status = "active"
-  vrf_id = netbox_vrf.test.id
-  vlan_id = netbox_vlan.test.id
-  site_id = netbox_site.test.id
+  prefix      = "%[3]s"
+  status      = "active"
+  vrf_id      = netbox_vrf.test.id
+  vlan_id     = netbox_vlan.test.id
+  tenant_id   = netbox_tenant.test.id
+  site_id     = netbox_site.test.id
   description = "%[1]s_description_test_idv6"
 }
 
@@ -61,46 +67,52 @@ data "netbox_prefix" "by_description" {
 
 data "netbox_prefix" "by_cidr" {
   depends_on = [netbox_prefix.testv4]
-  cidr = "%[2]s"
+  cidr       = "%[2]s"
 }
 
 data "netbox_prefix" "by_vrf_id" {
   depends_on = [netbox_prefix.testv4]
-  vrf_id = netbox_vrf.test.id
-  family = 4
+  vrf_id     = netbox_vrf.test.id
+  family     = 4
 }
 
 data "netbox_prefix" "by_vlan_id" {
   depends_on = [netbox_prefix.testv4]
-  vlan_id = netbox_vlan.test.id
-  family  = 4
+  vlan_id    = netbox_vlan.test.id
+  family     = 4
 }
 
 data "netbox_prefix" "by_vlan_vid" {
   depends_on = [netbox_prefix.testv4]
-  vlan_vid = %[4]d
-  family   = 4
+  vlan_vid   = %[4]d
+  family     = 4
 }
 
 data "netbox_prefix" "by_prefix" {
   depends_on = [netbox_prefix.testv4]
-  prefix = "%[2]s"
+  prefix     = "%[2]s"
+}
+
+data "netbox_prefix" "by_tenant_id" {
+  depends_on = [netbox_prefix.testv4]
+  tenant_id  = netbox_tenant.test.id
+  family     = 4
 }
 
 data "netbox_prefix" "by_site_id" {
   depends_on = [netbox_prefix.testv4]
-  site_id = netbox_site.test.id
-  family  = 4
+  site_id    = netbox_site.test.id
+  family     = 4
 }
 
 data "netbox_prefix" "by_role_id" {
   depends_on = [netbox_prefix.testv4]
-  role_id = netbox_ipam_role.test.id
+  role_id    = netbox_ipam_role.test.id
 }
 
 data "netbox_prefix" "by_family" {
   depends_on = [netbox_prefix.testv6]
-	family     = 6
+	family   = 6
 }
 
 `, testName, testv4Prefix, testv6Prefix, testVlanVid),
@@ -111,6 +123,7 @@ data "netbox_prefix" "by_family" {
 					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vrf_id", "id", "netbox_prefix.testv4", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vlan_id", "id", "netbox_prefix.testv4", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vlan_vid", "id", "netbox_prefix.testv4", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_tenant_id", "id", "netbox_prefix.testv4", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_site_id", "id", "netbox_prefix.testv4", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_role_id", "id", "netbox_prefix.testv4", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_family", "id", "netbox_prefix.testv6", "id"),

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -25,7 +25,7 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `site_id`, & `tag`.",
+							Description: "The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, & `tag`.",
 						},
 						"value": {
 							Type:        schema.TypeString,
@@ -57,6 +57,10 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 						},
 						"description": {
 							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tenant_id": {
+							Type:     schema.TypeInt,
 							Computed: true,
 						},
 						"site_id": {
@@ -119,6 +123,8 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 				params.VlanID = &vString
 			case "status":
 				params.Status = &vString
+			case "tenant_id":
+				params.TenantID = &vString
 			case "site_id":
 				params.SiteID = &vString
 			case "tag":
@@ -149,6 +155,9 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 		}
 		if v.Vrf != nil {
 			mapping["vrf_id"] = v.Vrf.ID
+		}
+		if v.Tenant != nil {
+			mapping["tenant_id"] = v.Tenant.ID
 		}
 		if v.Site != nil {
 			mapping["site_id"] = v.Site.ID

--- a/netbox/data_source_netbox_prefixes_test.go
+++ b/netbox/data_source_netbox_prefixes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccNetboxPrefixesDataSource_basic(t *testing.T) {
-	testPrefixes := []string{"10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24"}
+	testPrefixes := []string{"10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"}
 	testSlug := "prefixes_ds_basic"
 	testVlanVids := []int{4093, 4094}
 	testName := testAccGetTestName(testSlug)
@@ -38,24 +38,34 @@ resource "netbox_prefix" "without_vrf_and_vlan" {
   status = "active"
 }
 
+resource "netbox_tenant" "test" {
+  name = "%[1]s_tenant"
+}
+
+resource "netbox_prefix" "with_tenant_id" {
+  prefix    = "%[5]s"
+  status    = "active"
+  tenant_id = netbox_tenant.test.id
+}
+
 resource "netbox_site" "test" {
-  name = "site-%[1]s"
+  name     = "site-%[1]s"
   timezone = "Europe/Berlin"
 }
 
 resource "netbox_prefix" "with_site_id" {
-  prefix  = "%[5]s"
+  prefix  = "%[6]s"
   status  = "active"
   site_id = netbox_site.test.id
 }
 
 resource "netbox_site" "test2" {
-  name = "site2-%[1]s"
+  name     = "site2-%[1]s"
   timezone = "Europe/Berlin"
 }
 
 resource "netbox_prefix" "with_container" {
-  prefix  = "%[8]s"
+  prefix  = "%[9]s"
   status  = "container"
   site_id = netbox_site.test2.id
 }
@@ -66,12 +76,12 @@ resource "netbox_vrf" "test_vrf" {
 
 resource "netbox_vlan" "test_vlan1" {
   name = "%[1]s_vlan1"
-  vid  = %[6]d
+  vid  = %[7]d
 }
 
 resource "netbox_vlan" "test_vlan2" {
   name = "%[1]s_vlan2"
-  vid  = %[7]d
+  vid  = %[8]d
 }
 
 resource "netbox_tag" "test_tag1" {
@@ -94,7 +104,7 @@ data "netbox_prefixes" "by_vid" {
   depends_on = [netbox_prefix.test_prefix1, netbox_prefix.test_prefix2]
   filter {
     name  = "vlan_vid"
-    value = "%[6]d"
+    value = "%[7]d"
   }
 }
 
@@ -121,6 +131,15 @@ data "netbox_prefixes" "find_prefix_without_vrf_and_vlan" {
     value = netbox_prefix.without_vrf_and_vlan.prefix
   }
 }
+
+data "netbox_prefixes" "find_prefix_with_tenant_id" {
+  depends_on = [netbox_prefix.with_tenant_id]
+  filter {
+    name  = "tenant_id"
+    value = netbox_tenant.test.id
+  }
+}
+
 data "netbox_prefixes" "find_prefix_with_site_id" {
   depends_on = [netbox_prefix.with_site_id]
   filter {
@@ -133,11 +152,11 @@ data "netbox_prefixes" "find_prefix_with_contains" {
   depends_on = [netbox_prefix.with_container]
   filter {
     name  = "contains"
-    value = "10.0.8.50"
+    value = "10.0.9.50"
   }
 }
 
-`, testName, testPrefixes[0], testPrefixes[1], testPrefixes[2], testPrefixes[3], testVlanVids[0], testVlanVids[1], testPrefixes[4]),
+`, testName, testPrefixes[0], testPrefixes[1], testPrefixes[2], testPrefixes[3], testPrefixes[4], testVlanVids[0], testVlanVids[1], testPrefixes[5]),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_vrf", "prefixes.#", "2"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefixes.by_vrf", "prefixes.1.vlan_vid", "netbox_vlan.test_vlan2", "vid"),
@@ -145,10 +164,12 @@ data "netbox_prefixes" "find_prefix_with_contains" {
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_tag", "prefixes.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_tag", "prefixes.0.description", "my-description"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.no_results", "prefixes.#", "0"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_tenant_id", "prefixes.#", "1"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_tenant_id", "prefixes.0.prefix", "10.0.7.0/24"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_site_id", "prefixes.#", "1"),
-					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_site_id", "prefixes.0.prefix", "10.0.7.0/24"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_site_id", "prefixes.0.prefix", "10.0.8.0/24"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_contains", "prefixes.#", "1"),
-					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_contains", "prefixes.0.prefix", "10.0.8.0/24"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_contains", "prefixes.0.prefix", "10.0.9.0/24"),
 					resource.TestCheckResourceAttrSet("data.netbox_prefixes.find_prefix_with_contains", "prefixes.0.site_id"),
 				),
 			},


### PR DESCRIPTION
This PR enhances the `netbox_prefix` and `netbox_prefixes` datasources by adding support for the `tenant_id` filter parameter. This aligns the datasources with the existing `netbox_prefix` and `netbox_available_prefix` resources, ensuring a 1:1 relationship between resource creation and search capabilities. Relevant tests have been updated to validate the functionality of the new option.